### PR TITLE
Add post detail page and link from post list

### DIFF
--- a/posts/templates/posts/post_detail.html
+++ b/posts/templates/posts/post_detail.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>{{ post.title }}</title>
+</head>
+<body>
+    <h1>{{ post.title }}</h1>
+    <p>{{ post.content }}</p>
+    <small>作成日時：{{ post.created_at }}</small>
+    <br><br>
+    <a href="{% url 'post_list' %}">← 一覧に戻る</a>
+</body>
+</html>

--- a/posts/templates/posts/post_list.html
+++ b/posts/templates/posts/post_list.html
@@ -5,9 +5,14 @@
 </head>
 <body>
     <h1>投稿一覧</h1>
+
     {% for post in posts %}
         <div>
-            <h2>{{ post.title }}</h2>
+            <h2>
+                <a href="{% url 'post_detail' post.pk %}">
+                    {{ post.title }}
+                </a>
+            </h2>
             <p>{{ post.content }}</p>
             <small>{{ post.created_at }}</small>
         </div>

--- a/posts/urls.py
+++ b/posts/urls.py
@@ -3,4 +3,5 @@ from . import views
 
 urlpatterns = [
     path('', views.post_list, name='post_list'),
+    path('<int:pk>/', views.post_detail, name='post_detail'),# 投稿詳細ページのURL振り分け
 ]

--- a/posts/views.py
+++ b/posts/views.py
@@ -1,5 +1,5 @@
 #HTMLを生成して返す
-from django.shortcuts import render
+from django.shortcuts import render, get_object_or_404
 from .models import Post
 
 
@@ -7,3 +7,9 @@ from .models import Post
 def post_list(request):
     posts = Post.objects.all().order_by('-created_at')
     return render(request, 'posts/post_list.html', {'posts': posts})
+
+
+
+def post_detail(request, pk):
+    post = get_object_or_404(Post, pk=pk)
+    return render(request, 'posts/post_detail.html', {'post': post})


### PR DESCRIPTION
## 概要
- 投稿詳細ページを追加しました
- 投稿一覧ページのタイトルにリンクを追加し、クリックで詳細に遷移します

## 変更内容
- views.py に `post_detail` 関数追加
- urls.py に `<int:pk>/` を追加
- post_detail.html 作成
- post_list.html にリンク追加
