### PR TITLE
Add post creation page

### DIFF
--- a/posts/templates/posts/post_form.html
+++ b/posts/templates/posts/post_form.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>新規投稿</title>
+</head>
+<body>
+    <h1>新規投稿</h1>
+
+    <form method="POST">
+        {% csrf_token %}
+        <label>タイトル:</label><br>
+        <input type="text" name="title"><br><br>
+
+        <label>本文:</label><br>
+        <textarea name="content" rows="4" cols="50"></textarea><br><br>
+
+        <button type="submit">投稿する</button>
+    </form>
+
+    <br>
+    <a href="{% url 'post_list' %}">← 一覧に戻る</a>
+</body>
+</html>

--- a/posts/templates/posts/post_list.html
+++ b/posts/templates/posts/post_list.html
@@ -6,12 +6,13 @@
 <body>
     <h1>投稿一覧</h1>
 
+    <a href="{% url 'post_create' %}">＋ 新規投稿</a>
+    <hr>
+
     {% for post in posts %}
         <div>
             <h2>
-                <a href="{% url 'post_detail' post.pk %}">
-                    {{ post.title }}
-                </a>
+                <a href="{% url 'post_detail' post.pk %}">{{ post.title }}</a>
             </h2>
             <p>{{ post.content }}</p>
             <small>{{ post.created_at }}</small>

--- a/posts/urls.py
+++ b/posts/urls.py
@@ -4,4 +4,5 @@ from . import views
 urlpatterns = [
     path('', views.post_list, name='post_list'),
     path('<int:pk>/', views.post_detail, name='post_detail'),# 投稿詳細ページのURL振り分け
+    path('new/', views.post_create, name='post_create'),  # ←追加
 ]

--- a/posts/views.py
+++ b/posts/views.py
@@ -1,5 +1,5 @@
 #HTMLを生成して返す
-from django.shortcuts import render, get_object_or_404
+from django.shortcuts import render, get_object_or_404, redirect
 from .models import Post
 
 
@@ -9,7 +9,17 @@ def post_list(request):
     return render(request, 'posts/post_list.html', {'posts': posts})
 
 
-
 def post_detail(request, pk):
     post = get_object_or_404(Post, pk=pk)
     return render(request, 'posts/post_detail.html', {'post': post})
+
+
+def post_create(request):
+    if request.method == 'POST':
+        title = request.POST.get('title')
+        content = request.POST.get('content')
+        if title and content:
+            Post.objects.create(title=title, content=content)
+            return redirect('post_list')  # 投稿後は一覧に戻る
+    return render(request, 'posts/post_form.html')
+


### PR DESCRIPTION
## 目的
投稿作成機能を追加するため。

## 変更内容
- 投稿作成用のビュー (`post_create`) を追加
- 投稿フォーム用テンプレート (`post_form.html`) を追加
- `/new/` にルーティングを追加
- 一覧ページに「＋ 新規投稿」リンクを追加

## 動作確認
- 投稿フォームからタイトル・本文を入力して投稿できること
- 投稿後、一覧ページに表示されること
- 入力なしで送信した場合、投稿されないこと（※バリデーション追加前）

## 補足（任意）
- 今後、ModelForm やバリデーション処理も追加予定