### PR TITLE
Implement post edit feature

### DIFF
--- a/posts/templates/posts/post_detail.html
+++ b/posts/templates/posts/post_detail.html
@@ -8,6 +8,10 @@
     <p>{{ post.content }}</p>
     <small>作成日時：{{ post.created_at }}</small>
     <br><br>
+    <!-- 編集リンクを追加！ -->
+    <a href="{% url 'post_edit' post.pk %}">✏️ 編集する</a>
+
+    <br><br>
     <a href="{% url 'post_list' %}">← 一覧に戻る</a>
 </body>
 </html>

--- a/posts/templates/posts/post_form.html
+++ b/posts/templates/posts/post_form.html
@@ -1,20 +1,21 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>新規投稿</title>
+    <title>{% if post %}投稿を編集{% else %}新規投稿{% endif %}</title>
 </head>
 <body>
-    <h1>新規投稿</h1>
+    <h1>{% if post %}投稿を編集{% else %}新規投稿{% endif %}</h1>
 
     <form method="POST">
         {% csrf_token %}
+        
         <label>タイトル:</label><br>
-        <input type="text" name="title"><br><br>
+        <input type="text" name="title" value="{% if post %}{{ post.title }}{% endif %}"><br><br>
 
         <label>本文:</label><br>
-        <textarea name="content" rows="4" cols="50"></textarea><br><br>
+        <textarea name="content">{% if post %}{{ post.content }}{% endif %}</textarea><br><br>
 
-        <button type="submit">投稿する</button>
+        <button type="submit">{% if post %}更新{% else %}投稿する{% endif %}</button>
     </form>
 
     <br>

--- a/posts/urls.py
+++ b/posts/urls.py
@@ -5,4 +5,5 @@ urlpatterns = [
     path('', views.post_list, name='post_list'),
     path('<int:pk>/', views.post_detail, name='post_detail'),# 投稿詳細ページのURL振り分け
     path('new/', views.post_create, name='post_create'),  # ←追加
+    path('<int:pk>/edit/', views.post_edit, name='post_edit'),
 ]

--- a/posts/views.py
+++ b/posts/views.py
@@ -23,3 +23,13 @@ def post_create(request):
             return redirect('post_list')  # 投稿後は一覧に戻る
     return render(request, 'posts/post_form.html')
 
+def post_edit(request, pk):
+    post = get_object_or_404(Post, pk=pk)
+
+    if request.method == 'POST':
+        post.title = request.POST.get('title')
+        post.content = request.POST.get('content')
+        post.save()
+        return redirect('post_detail', pk=post.pk)
+
+    return render(request, 'posts/post_form.html', {'post': post})


### PR DESCRIPTION
## 概要
投稿編集機能を実装しました。

## やったこと
- 投稿詳細ページから「✏️ 編集」リンクを追加
- `post_edit` ビューを追加
- フォームは投稿作成と共通で使用（post_form.html）

## 確認手順
1. 一覧や詳細ページから編集リンクをクリック
2. フォームに既存データが表示される
3. 編集して保存 → 詳細ページにリダイレクトされる

## 備考
- ModelForm未使用。手動でPOSTデータを保存しています。
