### PR TITLE
Add post delete feature

### DIFF
--- a/posts/templates/posts/post_detail.html
+++ b/posts/templates/posts/post_detail.html
@@ -9,7 +9,10 @@
     <small>作成日時：{{ post.created_at }}</small>
     <br><br>
     <!-- 編集リンクを追加！ -->
-    <a href="{% url 'post_edit' post.pk %}">✏️ 編集する</a>
+    <a href="{% url 'post_edit' post.pk %}">✏️ 編集</a>
+
+    <!-- 削除リンクを追加！ -->
+     <a href="{% url 'post_delete' post.pk %}">🗑️ 削除</a>
 
     <br><br>
     <a href="{% url 'post_list' %}">← 一覧に戻る</a>

--- a/posts/urls.py
+++ b/posts/urls.py
@@ -4,6 +4,7 @@ from . import views
 urlpatterns = [
     path('', views.post_list, name='post_list'),
     path('<int:pk>/', views.post_detail, name='post_detail'),# 投稿詳細ページのURL振り分け
-    path('new/', views.post_create, name='post_create'),  # ←追加
-    path('<int:pk>/edit/', views.post_edit, name='post_edit'),
+    path('new/', views.post_create, name='post_create'),  # 新規投稿ページのURL振り分け
+    path('<int:pk>/edit/', views.post_edit, name='post_edit'),# 投稿編集ページのURL振り分け
+     path('<int:pk>/delete/', views.post_delete, name='post_delete'),  # 投稿削除ページのURL振り分け
 ]

--- a/posts/views.py
+++ b/posts/views.py
@@ -33,3 +33,8 @@ def post_edit(request, pk):
         return redirect('post_detail', pk=post.pk)
 
     return render(request, 'posts/post_form.html', {'post': post})
+
+def post_delete(request, pk):
+    post = get_object_or_404(Post, pk=pk)
+    post.delete()
+    return redirect('post_list')


### PR DESCRIPTION
## 概要
投稿を削除する機能を追加しました。

## やったこと
- `post_delete` ビュー関数の追加
- `urls.py` に `/delete/` のルーティングを追加
- 詳細ページに削除リンクを追加

## 確認方法
1. 任意の投稿詳細ページにアクセス
2. 「削除」リンクをクリック
3. 投稿が削除され、一覧ページに遷移する
