### PR TITLE
Add post create/edit with ModelForm

### DIFF
--- a/posts/forms.py
+++ b/posts/forms.py
@@ -1,0 +1,7 @@
+from django import forms
+from .models import Post
+
+class PostForm(forms.ModelForm):
+    class Meta:
+        model = Post
+        fields = ['title', 'content']

--- a/posts/templates/posts/post_form_modelform.html
+++ b/posts/templates/posts/post_form_modelform.html
@@ -1,0 +1,19 @@
+<!-- posts/templates/posts/post_form_modelform.html -->
+
+<!DOCTYPE html>
+<html>
+<head>
+    <title>ModelForm 投稿フォーム</title>
+</head>
+<body>
+    <h1>投稿フォーム（ModelForm）</h1>
+
+    <form method="POST">
+        {% csrf_token %}
+        {{ form.as_p }}  <!-- ← 超シンプルに！ -->
+        <button type="submit">保存</button>
+    </form>
+
+    <a href="{% url 'post_list' %}">← 一覧に戻る</a>
+</body>
+</html>

--- a/posts/urls.py
+++ b/posts/urls.py
@@ -4,7 +4,9 @@ from . import views
 urlpatterns = [
     path('', views.post_list, name='post_list'),
     path('<int:pk>/', views.post_detail, name='post_detail'),# 投稿詳細ページのURL振り分け
-    path('new/', views.post_create, name='post_create'),  # 新規投稿ページのURL振り分け
-    path('<int:pk>/edit/', views.post_edit, name='post_edit'),# 投稿編集ページのURL振り分け
-     path('<int:pk>/delete/', views.post_delete, name='post_delete'),  # 投稿削除ページのURL振り分け
+    #path('new/', views.post_create, name='post_create'),  # 新規投稿ページのURL振り分け
+    #path('<int:pk>/edit/', views.post_edit, name='post_edit'),# 投稿編集ページのURL振り分け
+    path('<int:pk>/delete/', views.post_delete, name='post_delete'),  # 投稿削除ページのURL振り分け
+    path('new/', views.post_create_form, name='post_create'),# ModelForm版 新規投稿ページのURL振り分け
+    path('<int:pk>/edit/', views.post_edit_form, name='post_edit'),# ModelForm版 投稿編集ページのURL振り分け
 ]

--- a/posts/views.py
+++ b/posts/views.py
@@ -1,7 +1,7 @@
 #HTMLを生成して返す
 from django.shortcuts import render, get_object_or_404, redirect
 from .models import Post
-
+from .forms import PostForm
 
 # Create your views here.
 def post_list(request):
@@ -13,7 +13,7 @@ def post_detail(request, pk):
     post = get_object_or_404(Post, pk=pk)
     return render(request, 'posts/post_detail.html', {'post': post})
 
-
+"""
 def post_create(request):
     if request.method == 'POST':
         title = request.POST.get('title')
@@ -33,8 +33,34 @@ def post_edit(request, pk):
         return redirect('post_detail', pk=post.pk)
 
     return render(request, 'posts/post_form.html', {'post': post})
+"""
 
 def post_delete(request, pk):
     post = get_object_or_404(Post, pk=pk)
     post.delete()
     return redirect('post_list')
+
+
+# ModelForm版: 新規投稿
+def post_create_form(request):
+    if request.method == 'POST':
+        form = PostForm(request.POST)
+        if form.is_valid():
+            post = form.save()
+            return redirect('post_detail', pk=post.pk)
+    else:
+        form = PostForm()
+    return render(request, 'posts/post_form_modelform.html', {'form': form})
+
+
+# ModelForm版: 編集
+def post_edit_form(request, pk):
+    post = get_object_or_404(Post, pk=pk)
+    if request.method == 'POST':
+        form = PostForm(request.POST, instance=post)
+        if form.is_valid():
+            post = form.save()
+            return redirect('post_detail', pk=post.pk)
+    else:
+        form = PostForm(instance=post)
+    return render(request, 'posts/post_form_modelform.html', {'form': form})


### PR DESCRIPTION
## 概要
手動で実装していた投稿フォームを、ModelFormベースに切り替えました。

## 変更点
- `forms.py` に `PostForm` を追加
- `post_create_form`, `post_edit_form` ビューを作成
- 一覧・詳細ページのリンクを変更し、画面遷移を統一

## 確認方法
- `/new/` から投稿が作成できること
- `/1/edit/` から投稿が編集できること
- 保存後に詳細ページへリダイレクトされること

## 備考
旧バージョンの手動実装は削除済み
